### PR TITLE
Improve URL normalisation and add full regression tests

### DIFF
--- a/src/spider/utils.py
+++ b/src/spider/utils.py
@@ -15,16 +15,61 @@ def init_logging(log_level: int = logging.INFO) -> None:
 
 def normalize_url(url: str) -> str:
     """
-    Normalize a URL by removing trailing slashes and sorting query parameters.
-
+    Normalize a URL by applying the following rules:
+    1. Lower-case scheme and host, strip leading "www.".
+    2. Remove URL path parameters such as ";jsessionid=…".
+    3. Remove trailing slashes from the path.
+    4. Remove common tracking query parameters (utm_*, ref, gclid, fbclid, etc.).
+    5. Remove common session identifiers from query (phpsessid, jsessionid, asp.net_sessionid, etc.).
+    6. Sort the remaining query parameters for a stable ordering.
     :param url: The URL to normalize.
     :return: Normalized URL.
     """
     parsed = urlparse(url)
-    path = parsed.path.rstrip('/')
-    # Sort query parameters to ensure consistent ordering.
-    query = urlencode(sorted(parse_qsl(parsed.query)))
-    normalized = urlunparse((
-        parsed.scheme, parsed.netloc, path, parsed.params, query, parsed.fragment
-    ))
+
+    # 1. Canonicalise scheme and host
+    scheme = parsed.scheme.lower()
+    netloc = parsed.netloc.lower()
+    if netloc.startswith("www."):
+        netloc = netloc[4:]
+
+    # 2. Remove path parameters (matrix parameters) such as ";jsessionid=…"
+    path = parsed.path
+    if ";" in path:
+        path = path.split(";")[0]
+    # 3. Remove trailing slash entirely, including for root path
+    path = path.rstrip("/")
+
+    # 4 & 5. Filter query parameters
+    TRACKING_PREFIXES = ("utm_",)
+    TRACKING_PARAMS = {
+        "ref",
+        "gclid",
+        "fbclid",
+        "fb_source",
+        "igshid",
+    }
+    SESSION_PARAMS = {
+        "phpsessid",
+        "jsessionid",
+        "sessionid",
+        "sid",
+        "asp.net_sessionid",
+    }
+
+    filtered_qsl = [
+        (k.lower(), v)
+        for k, v in parse_qsl(parsed.query, keep_blank_values=True)
+        if (
+            k.lower() not in TRACKING_PARAMS
+            and k.lower() not in SESSION_PARAMS
+            and not any(k.lower().startswith(prefix) for prefix in TRACKING_PREFIXES)
+        )
+    ]
+
+    # 6. Sort remaining params for stability
+    query = urlencode(sorted(filtered_qsl))
+
+    # Fragment is deliberately dropped.
+    normalized = urlunparse((scheme, netloc, path, "", query, ""))
     return normalized

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,61 @@
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+import pytest
+
+from spider.utils import normalize_url
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Lower-case host and scheme + remove trailing slash
+        (
+            "HTTPS://Example.COM/path/",
+            "https://example.com/path",
+        ),
+        # Strip www subdomain
+        (
+            "https://www.example.com/",
+            "https://example.com",
+        ),
+        # Remove tracking params (utm_*) and sort remaining
+        (
+            "https://example.com/?b=2&utm_source=newsletter&a=1",
+            "https://example.com?a=1&b=2",
+        ),
+        # Remove fixed tracking params (gclid, fbclid, ref)
+        (
+            "https://example.com/page?ref=twitter&gclid=123&x=1",
+            "https://example.com/page?x=1",
+        ),
+        # Remove session params in query
+        (
+            "https://example.com/?PHPSESSID=42&foo=bar",
+            "https://example.com?foo=bar",
+        ),
+        # Remove session id in path (jsessionid)
+        (
+            "https://example.com/page;jsessionid=ABCDEF123?x=1",
+            "https://example.com/page?x=1",
+        ),
+        # Combine several rules
+        (
+            "https://WWW.EXAMPLE.com/path/;JSESSIONID=xyz?utm_medium=email&sid=33&B=2&a=1#section",
+            "https://example.com/path?a=1&b=2",
+        ),
+        # No query should still work
+        (
+            "https://example.com",
+            "https://example.com",
+        ),
+        # Root path with slash preserved (should remove trailing slash though)
+        (
+            "https://example.com/",
+            "https://example.com",
+        ),
+    ],
+)
+
+def test_normalize_url(raw, expected):
+    assert normalize_url(raw) == expected


### PR DESCRIPTION
**Enhanced URL canonicalisation (src/spider/utils.py)**
• Lower-cases scheme + host, strips leading www.
• Removes path session tokens (;jsessionid=…) and any trailing slash
• Filters tracking parameters (utm_*, ref, gclid, fbclid, …)
• Filters session IDs (PHPSESSID, sid, asp.net_sessionid, …)
• Lower-cases & sorts remaining query keys for stable ordering

**New test suite**
Nine parametric Pytest cases guarding edge scenarios: casing, www.
folding, tracking & session stripping, trailing slash behaviour, etc.
